### PR TITLE
feat(script): 图标经后端代理，坏图统一首字母兜底

### DIFF
--- a/src/app/[locale]/(main)/script-show-page/[id]/components/ScriptDetailClient.tsx
+++ b/src/app/[locale]/(main)/script-show-page/[id]/components/ScriptDetailClient.tsx
@@ -23,7 +23,6 @@ import {
 } from 'antd';
 import {
   DownloadOutlined,
-  CodeOutlined,
   CalendarOutlined,
   UserOutlined,
   MoreOutlined,
@@ -61,6 +60,7 @@ import { aiReviewService } from '@/lib/api/services/aiReview';
 import { useTranslations } from 'next-intl';
 import ActionMenu from '@/components/ActionMenu';
 import AdSlot from '@/components/AdSlot';
+import ScriptIcon from '@/components/ScriptIcon';
 import type { AdSlotItem } from '@/lib/api/services/advertise';
 import ScriptVersionsClient from '../version/components/ScriptVersionsClient';
 import ScriptRatingClient from '../comment/components/ScriptRatingClient';
@@ -555,11 +555,6 @@ export default function ScriptDetailClient({
     }
   }, [quickFavorite, t]);
 
-  const icon = useMemo(
-    () => ScriptUtils.icon(script.script.meta_json),
-    [script.script.meta_json],
-  );
-
   const handleCopyRequireClick = useCallback(() => {
     const requireLink =
       requireSelect == 1
@@ -824,12 +819,12 @@ export default function ScriptDetailClient({
               {/* 头部卡：头像/标题/作者·创建于/简介/标签 */}
               <Card className="shadow-sm">
                 <div className="flex items-start space-x-4">
-                  <Avatar
-                    shape="square"
+                  <ScriptIcon
+                    script={script}
+                    name={scriptName}
                     size={64}
-                    src={icon}
-                    icon={<CodeOutlined />}
-                    className="bg-gradient-to-br from-blue-500 to-purple-600"
+                    radius={8}
+                    textSize="text-2xl"
                   />
                   <div className="flex-1 ml-2">
                     <Title level={2} className="mb-2">

--- a/src/app/[locale]/(main)/script-show-page/[id]/utils.ts
+++ b/src/app/[locale]/(main)/script-show-page/[id]/utils.ts
@@ -17,6 +17,15 @@ const superBrowserMap: Record<string, Browser> = {
   opera: { logo: 'opera', name: 'Opera' },
 };
 
+/**
+ * ScriptUtils.icon 需要的最小结构。ScriptListItem 与 ScriptInfo 都满足它。
+ */
+export type ScriptIconSource = {
+  id: number;
+  updatetime?: number;
+  script?: { meta_json?: Metadata };
+};
+
 export class ScriptUtils {
   static score(score: number, score_num: number): string | null {
     return score ? (score / score_num / 10).toFixed(1) : null;
@@ -63,14 +72,23 @@ export class ScriptUtils {
     });
   }
 
-  static icon(metaJson: MetaJson): string | null {
-    if (metaJson.icon) {
-      return metaJson.icon[0];
+  /**
+   * 返回图标的后端代理 URL。
+   *
+   * 图标一律经 /api/v2/scripts/:id/icon 走 scriptcat.org,浏览器不再直连
+   * 作者填的第三方站点。meta_json 里的原始值只用来判断「有没有图标」,
+   * URL 由 id + updatetime 重建,因此对已 slim 过的数据同样幂等。
+   *
+   * 没有图标时返回 null,调用方渲染兜底(不必请求接口)。
+   */
+  static icon(script: ScriptIconSource): string | null {
+    const meta = script.script?.meta_json;
+    const raw = meta?.icon?.[0] ?? meta?.iconURL?.[0];
+    if (!raw) {
+      return null;
     }
-    if (metaJson.iconURL) {
-      return metaJson.iconURL[0];
-    }
-    return null;
+    const t = script.updatetime ? `?t=${script.updatetime}` : '';
+    return `/api/v2/scripts/${script.id}/icon${t}`;
   }
 
   static getRibbonText(publicStatus: number): string | null {

--- a/src/components/ScriptIcon.tsx
+++ b/src/components/ScriptIcon.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useState } from 'react';
+import { ScriptUtils } from '@/app/[locale]/(main)/script-show-page/[id]/utils';
+import type { ScriptIconSource } from '@/app/[locale]/(main)/script-show-page/[id]/utils';
+import type { ReactNode } from 'react';
+
+const iconPalette = [
+  '#ef4444',
+  '#f97316',
+  '#f59e0b',
+  '#10b981',
+  '#06b6d4',
+  '#0d6efd',
+  '#8b5cf6',
+  '#a855f7',
+  '#ec4899',
+  '#0891b2',
+];
+
+export function pickIconColor(id: number): string {
+  return iconPalette[Math.abs(id) % iconPalette.length];
+}
+
+function firstChar(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) return '?';
+  const ch = trimmed.charAt(0);
+  return /[a-zA-Z]/.test(ch) ? ch.toUpperCase() : ch;
+}
+
+interface ScriptIconProps {
+  script: ScriptIconSource;
+  /** 兜底首字母的来源。详情页的标题与 script.name 可能不同，故单独传。 */
+  name: string;
+  size: number;
+  radius?: number;
+  textSize?: string;
+  /** 覆盖默认的首字母色块兜底。ScriptListCard 用它保留排名 Tag。 */
+  fallback?: ReactNode;
+  className?: string;
+}
+
+/**
+ * 脚本图标。图标经后端代理由 scriptcat.org 提供；加载失败（后端确认坏图会
+ * 返回 404）时回退到首字母色块，不会出现浏览器裂图。
+ */
+export default function ScriptIcon({
+  script,
+  name,
+  size,
+  radius = 6,
+  textSize = 'text-sm',
+  fallback,
+  className = '',
+}: ScriptIconProps) {
+  const [hasError, setHasError] = useState(false);
+  const iconUrl = ScriptUtils.icon(script);
+
+  if (iconUrl && !hasError) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+      <img
+        src={iconUrl}
+        width={size}
+        height={size}
+        loading="lazy"
+        className={`flex-shrink-0 object-cover ${className}`}
+        style={{ borderRadius: radius }}
+        onError={() => setHasError(true)}
+      />
+    );
+  }
+
+  if (fallback !== undefined) {
+    return <>{fallback}</>;
+  }
+
+  return (
+    <div
+      style={{
+        background: pickIconColor(script.id),
+        width: size,
+        height: size,
+        borderRadius: radius,
+      }}
+      className={`flex-shrink-0 flex items-center justify-center text-white font-bold leading-none ${textSize} ${className}`}
+    >
+      {firstChar(name)}
+    </div>
+  );
+}

--- a/src/components/ScriptListCard.tsx
+++ b/src/components/ScriptListCard.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { Card, Avatar, Tag, Typography, Space } from 'antd';
+import { Card, Tag, Typography, Space } from 'antd';
 import { Link } from '@/i18n/routing';
-import { ScriptUtils } from '@/app/[locale]/(main)/script-show-page/[id]/utils';
 import { hashColor } from '@/lib/utils/utils';
+import ScriptIcon from '@/components/ScriptIcon';
 import type { ReactNode } from 'react';
 import type { ScriptListItem } from '@/app/[locale]/(main)/script-show-page/[id]/types';
 
@@ -36,9 +36,6 @@ export default function ScriptListCard({
     >
       <div>
         {data.map((item, index) => {
-          const scriptIcon = item.script?.meta_json
-            ? ScriptUtils.icon(item.script.meta_json)
-            : null;
           const itemTitle = item.name;
           const itemId = item.id;
 
@@ -50,17 +47,22 @@ export default function ScriptListCard({
               target="_blank"
             >
               <div className="flex items-center gap-3 w-full px-2">
-                {scriptIcon ? (
-                  <Avatar size={24} src={scriptIcon} shape="square" />
-                ) : (
-                  <Tag
-                    className="!m-0"
-                    color={hashColor((index + 1).toString())}
-                    style={index === 9 ? { padding: '0 3px' } : {}}
-                  >
-                    {index + 1}
-                  </Tag>
-                )}
+                <ScriptIcon
+                  script={item}
+                  name={itemTitle}
+                  size={24}
+                  radius={4}
+                  textSize="text-xs"
+                  fallback={
+                    <Tag
+                      className="!m-0"
+                      color={hashColor((index + 1).toString())}
+                      style={index === 9 ? { padding: '0 3px' } : {}}
+                    >
+                      {index + 1}
+                    </Tag>
+                  }
+                />
                 <div className="flex-1 min-w-0">
                   <Text
                     className="text-sm font-medium text-gray-900 dark:text-white hover:text-blue-600 dark:hover:text-blue-400 transition-colors block"

--- a/src/components/ScriptSection.tsx
+++ b/src/components/ScriptSection.tsx
@@ -8,6 +8,7 @@ import { useLocale, useTranslations } from 'next-intl';
 import { formatNumber, useSemDateTime } from '@/lib/utils/semdate';
 import { ScriptUtils } from '@/app/[locale]/(main)/script-show-page/[id]/utils';
 import type { ScriptListItem } from '@/app/[locale]/(main)/script-show-page/[id]/types';
+import ScriptIcon from '@/components/ScriptIcon';
 
 const { Text } = Typography;
 
@@ -18,70 +19,6 @@ interface ScriptSectionProps {
   title: string;
   moreHref: string;
   scripts: ScriptListItem[];
-}
-
-const iconPalette = [
-  '#ef4444',
-  '#f97316',
-  '#f59e0b',
-  '#10b981',
-  '#06b6d4',
-  '#0d6efd',
-  '#8b5cf6',
-  '#a855f7',
-  '#ec4899',
-  '#0891b2',
-];
-
-function pickIconColor(id: number): string {
-  return iconPalette[Math.abs(id) % iconPalette.length];
-}
-
-function firstChar(name: string): string {
-  const trimmed = name.trim();
-  if (!trimmed) return '?';
-  const ch = trimmed.charAt(0);
-  return /[a-zA-Z]/.test(ch) ? ch.toUpperCase() : ch;
-}
-
-function ScriptIcon({
-  script,
-  size,
-  radius,
-  textSize,
-}: {
-  script: ScriptListItem;
-  size: number;
-  radius: number;
-  textSize: string;
-}) {
-  const iconUrl = ScriptUtils.icon(script.script.meta_json);
-  if (iconUrl) {
-    return (
-      // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
-      <img
-        src={iconUrl}
-        width={size}
-        height={size}
-        loading="lazy"
-        className="flex-shrink-0 object-cover"
-        style={{ borderRadius: radius }}
-      />
-    );
-  }
-  return (
-    <div
-      style={{
-        background: pickIconColor(script.id),
-        width: size,
-        height: size,
-        borderRadius: radius,
-      }}
-      className={`flex-shrink-0 flex items-center justify-center text-white font-bold leading-none ${textSize}`}
-    >
-      {firstChar(script.name)}
-    </div>
-  );
 }
 
 function CompactCard({ script }: { script: ScriptListItem }) {
@@ -101,6 +38,7 @@ function CompactCard({ script }: { script: ScriptListItem }) {
         <div className="flex items-center gap-3">
           <ScriptIcon
             script={script}
+            name={name}
             size={44}
             radius={10}
             textSize="text-xl"
@@ -162,7 +100,13 @@ function ListRow({ script }: { script: ScriptListItem }) {
       target="_blank"
       className="flex items-center gap-4 px-4 py-2 hover:bg-[rgb(var(--primary-50))] dark:hover:bg-[rgb(33,38,45)] transition-colors"
     >
-      <ScriptIcon script={script} size={24} radius={6} textSize="text-xs" />
+      <ScriptIcon
+        script={script}
+        name={name}
+        size={24}
+        radius={6}
+        textSize="text-xs"
+      />
       <div className="w-[260px] flex-shrink-0 min-w-0">
         <Text
           strong

--- a/src/components/Scriptlist/ScriptCard.tsx
+++ b/src/components/Scriptlist/ScriptCard.tsx
@@ -26,8 +26,8 @@ import type { ScriptListItem } from '@/app/[locale]/(main)/script-show-page/[id]
 import { ScriptUtils } from '@/app/[locale]/(main)/script-show-page/[id]/utils';
 import { hashColor } from '@/lib/utils/utils';
 import React, { useCallback, useMemo, type ReactNode } from 'react';
-import { useState } from 'react';
 import ActionMenu from '@/components/ActionMenu';
+import ScriptIcon from '@/components/ScriptIcon';
 import { scriptService } from '@/lib/api/services/scripts';
 
 const { Text } = Typography;
@@ -38,36 +38,6 @@ const descriptionStyle: React.CSSProperties = {
   WebkitBoxOrient: 'vertical',
   overflow: 'hidden',
 };
-
-interface ScriptIconProps {
-  script: ScriptListItem;
-  size?: number;
-}
-
-const ScriptIcon = React.memo(function ScriptIcon({
-  script,
-  size = 20,
-}: ScriptIconProps) {
-  const [hasError, setHasError] = useState(false);
-  const iconUrl = ScriptUtils.icon(script.script.meta_json);
-
-  if (!iconUrl || hasError) {
-    return null;
-  }
-
-  return (
-    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
-    <img
-      src={iconUrl}
-      loading="lazy"
-      width={size}
-      height={size}
-      className="flex-shrink-0 rounded"
-      onError={() => setHasError(true)}
-      onLoad={() => setHasError(false)}
-    />
-  );
-});
 
 interface ActionButton {
   key: string;
@@ -158,11 +128,9 @@ export default React.memo(function ScriptCard({
           <div className="flex-1">
             {/* 主标题区域 - 脚本图标 + 标题 + 版本 */}
             <div className="flex items-start gap-3 mb-3">
-              {ScriptUtils.icon(script.script.meta_json) && (
-                <div className="flex-shrink-0 mt-1">
-                  <ScriptIcon script={script} size={40} />
-                </div>
-              )}
+              <div className="flex-shrink-0 mt-1">
+                <ScriptIcon script={script} name={script.name} size={40} />
+              </div>
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2 mb-1 flex-wrap">
                   <Link

--- a/src/lib/utils/script-slim.ts
+++ b/src/lib/utils/script-slim.ts
@@ -5,8 +5,12 @@ import type {
 
 /**
  * 裁剪 meta_json，只保留列表渲染需要的字段：
- * - icon / iconURL（图标）— base64 data URI 替换为后端代理 URL
+ * - icon / iconURL（图标）— 值一律替换为后端代理 URL
  * - name:* / description:*（i18n 本地化名称和描述）
+ *
+ * 图标原始值(尤其是 base64 data URI)可能很大，而前端只需要知道「有没有
+ * 图标」——URL 由 ScriptUtils.icon 从 id 重建。所以这里无条件替换掉原始值，
+ * SSR 载荷里不再出现内联图标数据。
  *
  * @param scriptId 脚本 ID，用于生成 icon 代理 URL
  * @param updatetime 脚本更新时间，附加到 icon URL 用于缓存失效
@@ -30,10 +34,9 @@ function slimMetaJson(
     }
   }
 
-  // 将 base64 data URI 替换为后端 icon 代理接口 URL
   if (scriptId) {
     const iconKey = slim['icon'] ? 'icon' : slim['iconURL'] ? 'iconURL' : null;
-    if (iconKey && slim[iconKey]?.[0]?.startsWith('data:')) {
+    if (iconKey && slim[iconKey]?.[0]) {
       const t = updatetime ? `?t=${updatetime}` : '';
       slim[iconKey] = [`/api/v2/scripts/${scriptId}/icon${t}`];
     }
@@ -83,6 +86,7 @@ export function slimScriptList(list: ScriptListItem[]): ScriptListItem[] {
 /**
  * 裁剪 ScriptListItem 列表，只保留侧边栏 ScriptListCard 所需的最少字段：
  * - id, name（标题和链接）
+ * - updatetime（ScriptUtils.icon 重建代理 URL 时的缓存失效参数）
  * - script.meta_json 中的 icon/iconURL（图标）
  */
 export function slimScriptListForSidebar(
@@ -93,6 +97,7 @@ export function slimScriptListForSidebar(
       ({
         id: item.id,
         name: item.name,
+        updatetime: item.updatetime,
         script: {
           meta_json: slimMetaJson(
             item.script.meta_json,

--- a/src/lib/utils/script-slim.ts
+++ b/src/lib/utils/script-slim.ts
@@ -5,12 +5,13 @@ import type {
 
 /**
  * 裁剪 meta_json，只保留列表渲染需要的字段：
- * - icon / iconURL（图标）— 值一律替换为后端代理 URL
+ * - icon / iconURL（图标）— 值一律替换为后端代理 URL，无原始值留存
  * - name:* / description:*（i18n 本地化名称和描述）
  *
  * 图标原始值(尤其是 base64 data URI)可能很大，而前端只需要知道「有没有
  * 图标」——URL 由 ScriptUtils.icon 从 id 重建。所以这里无条件替换掉原始值，
- * SSR 载荷里不再出现内联图标数据。
+ * SSR 载荷里不再出现内联图标数据。同时删除未被选中的图标字段，防止另一个
+ * 字段的原始值被序列化到 HTML 中。
  *
  * @param scriptId 脚本 ID，用于生成 icon 代理 URL
  * @param updatetime 脚本更新时间，附加到 icon URL 用于缓存失效
@@ -39,6 +40,9 @@ function slimMetaJson(
     if (iconKey && slim[iconKey]?.[0]) {
       const t = updatetime ? `?t=${updatetime}` : '';
       slim[iconKey] = [`/api/v2/scripts/${scriptId}/icon${t}`];
+      // Delete the other icon field to avoid serializing raw icon data (which may be large base64)
+      const otherIconKey = iconKey === 'icon' ? 'iconURL' : 'icon';
+      delete slim[otherIconKey];
     }
   }
 


### PR DESCRIPTION
配合 scriptscat/scriptlist#4：让浏览器在浏览脚本列表时不再直连脚本作者填写的第三方站点取图标。

后端 PR：scriptscat/scriptlist#5。

⚠️ **必须与后端一起发，且后端先上线。** 本 PR 让所有图标指向 `/api/v2/scripts/:id/icon`；该路由在后端上线前不存在，前端若先部署，**全站脚本图标会立刻全部退化成首字母色块**（`onError` 兜底，不会白屏或报错，但外观是全坏的）。

## 改了什么

`ScriptUtils.icon()` 的签名从 `icon(metaJson)` 改成 `icon(script)`，恒定返回 `/api/v2/scripts/${id}/icon?t=${updatetime}` —— 调用方**拿不到**作者填的原始 URL，这是靠类型强制的，不是靠自觉。原始值只被读取真假（判断该不该显示图标），URL 由 `id` + `updatetime` 重建，因此重复套用也不会双重包装。

全部 5 个脚本图标渲染点收敛到新的共享组件 `<ScriptIcon>`：`Scriptlist/ScriptCard`、`ScriptSection`（CompactCard + ListRow）、`ScriptListCard`、`ScriptDetailClient`。全仓 `ScriptUtils.icon` 只剩 1 个调用点。

**坏图兜底统一成首字母色块**（`onError` 切到色块而非换 src，因此不会有 onError 死循环）。`ScriptListCard` 通过 `fallback` prop 保留原有的名次 Tag。

`script-slim.ts` 里同时删除两个原始图标字段，避免 SSR 载荷里残留作者填的 URL（即使不渲染，也不该把这些域名写进 HTML）。

## 验证

`pnpm lint` 干净、`npx tsc --noEmit` exit 0。在本地起全栈对着 dev 环境实测：列表页 24 张卡片的图标 `src` 全部是 `/api/v2/scripts/:id/icon?t=...`，**DOM 里没有任何作者填的第三方 URL**；命中时同源返回真实 PNG，带 CSP sandbox + nosniff。

## 已知 follow-up（不在本 PR）

- `icon: [""]` 时前后端处理有分歧：后端跳过空串取 `iconURL`，前端不跳过 → 该脚本会显示首字母色块，且原始 `iconURL` 仍留在 SSR 载荷里（不发起请求，故不产生连接泄露）
- 详情页 `layout.tsx` 只剥了 `content`，`scriptMeta` 全量下发 → RSC 载荷里仍有原始 `icon`/`iconURL`（同上，不产生连接）
- `ScriptIcon` 位于 `src/components/` 却反向依赖页面内部路径的 `utils`，依赖方向倒置，宜下沉到 `src/lib/utils/`
- `Scriptlist/ScriptCard` 传给色块的是非 i18n 的 `script.name`，与同组件标题用的 `ScriptUtils.i18nName(...)` 不一致
- `ScriptIcon` 无 `alt`/`aria-label`，色块对屏幕阅读器不可读
